### PR TITLE
Make the socket non-blocking and connect asychronously

### DIFF
--- a/src/openspace/src/api.py
+++ b/src/openspace/src/api.py
@@ -69,10 +69,10 @@ class Api:
 
         self._socket.onDisconnect(callback)
 
-    def connect(self):
+    async def connect(self):
         """ Connect to OpenSpace. """
 
-        self._socket.connect()
+        await self._socket.connect()
 
     def disconnect(self):
         """ Disconnect from OpenSpace. """

--- a/src/openspace/src/socketwrapper.py
+++ b/src/openspace/src/socketwrapper.py
@@ -48,12 +48,13 @@ class SocketWrapper:
                 break
         self.disconnect()
 
-    def connect(self):
+    async def connect(self):
         self._client = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+        self._client.setblocking(False)
+        self._loop = asyncio.get_event_loop()
         try:
-            self._client.connect((self._address, self._port))
+            await self._loop.sock_connect(self._client, (self._address, self._port))
             self._disconnecting = False
-            self._loop = asyncio.get_event_loop()
             asyncio.create_task(self._handle_receive(), name="Handle receive")
             asyncio.create_task(self._onConnect(), name="On connect")
         except ConnectionRefusedError as e:


### PR DESCRIPTION
I was unable to use this module. When calling the `connect` method, asyncio was complaining that the socket must be non-blocking (might have to enable asyncio debugging to get the error, otherwise it will silently do nothing).

Use asyncio's sock_connect method instead of manually connecting the socket and make the socket non-blocking as required. To make this fully work, I had to make the `connect` method async all the way to the top.

With these changes, I can use this module:
- in an interactive IPython shell or a jupyter notebook like so:

    ````python
    import openspace
    import asyncio

    ADDRESS = 'localhost'
    PORT = 4681

    api = openspace.Api(ADDRESS, PORT)
    await api.connect()
    os = await api.singleReturnLibrary()
    await os.time.togglePause()
    ````

- in a regular script like so:

    ```python
    #! /usr/bin/env python3

    import openspace
    import asyncio

    ADDRESS = 'localhost'
    PORT = 4681

    api = openspace.Api(ADDRESS, PORT)

    async def init():
        await api.connect()
        os = await api.singleReturnLibrary()
        return os

    async def main():
        os = await init()
        await os.time.togglePause()
 
    asyncio.run(main())
    ```

Note: I'm far from a Python async expert... I did not find how to keep `connect` as a regular (non-async) method; if you believe that's a problem, I open to suggestions on how to fix it.