### PR TITLE
Sync api example

### DIFF
--- a/example/sync-example.py
+++ b/example/sync-example.py
@@ -1,0 +1,29 @@
+import asyncio
+import openspace
+
+# This is an example of how to make synchronous calls to the API
+# This is not so useful in scripts but has its use in interactive shells, instead of prepending
+# every call with `await`.
+
+ADDRESS = 'localhost'
+PORT = 4681
+# Create an OpenSpaceApi instance with the OpenSpace address and port
+api = openspace.Api(ADDRESS, PORT)
+
+# You might want to handle this differently according to your environment or use-case.
+# For instance, this works in a regular python shell or in IPython but `python3 -m asyncio` is
+# different.
+loop = asyncio.new_event_loop()
+def sync_wrapper(f, *args, **kwargs):
+    return loop.run_until_complete(f(*args, **kwargs))
+
+# warning: all async calls must be performed on the same loop
+
+loop.run_until_complete(api.connect())
+sync_os = loop.run_until_complete(api.singleReturnLibrary(sync_wrapper))
+
+# Calls to methods of `sync_os` will block until the call is made and a result is returned:
+sync_os.printInfo("foo")
+print(sync_os.propertyValue("Scene.Earth.Scale.Scale"))
+
+api.disconnect()

--- a/src/openspace/src/api.py
+++ b/src/openspace/src/api.py
@@ -322,21 +322,9 @@ class Api:
         else:
             topic.cancel()
 
-    async def library(self, multiReturn: bool) -> NamedTuple:
+    async def library(self) -> dict:
         """ Get an object representing the OpenSpace lua libarary. \n
-        :param multiReturn - whether the library should return the raw lua tables.
-        If this value is true, the 1-indexed lua table will be returned as a dict
-        If the value is false, then only the first return value will be returned. \n
         :return - The lua library, mapped to async python functions. """
-
-        def generateAsyncMultiRetFunction(functionName):
-            async def fun(*args):
-                try:
-                    return await self.executeLuaFunction(functionName, args)
-                except Exception as e:
-                    print("Lua exception error: \n", e)
-
-            return fun
 
         def generateAsyncSingleRetFunction(functionName):
             async def fun(*args):
@@ -366,10 +354,7 @@ class Api:
                 _lib = '' if subPyLibrary == pyLibrary else libraryName + '.'
                 fullFunctionName = 'openspace.' + _lib + func['name']
 
-                if multiReturn:
-                    subPyLibrary[func['name']] = generateAsyncMultiRetFunction(fullFunctionName)
-                else:
-                    subPyLibrary[func['name']] = generateAsyncSingleRetFunction(fullFunctionName)
+                subPyLibrary[func['name']] = generateAsyncSingleRetFunction(fullFunctionName)
 
         return self.toNamedTuple(pyLibrary, libraryName)
 
@@ -392,10 +377,3 @@ class Api:
         returns the first return value. """
 
         return await self.library(False)
-
-    async def multiReturnLibrary(self):
-        """ Get an object representing the OpenSpace lua library. \n
-        :return - The lua library, mapped to async python functions. The values returned
-        by the async functions will be the entire lua tables, with 1-indexed values. """
-
-        return await self.library(True)

--- a/src/openspace/src/api.py
+++ b/src/openspace/src/api.py
@@ -6,6 +6,21 @@ from .socketwrapper import SocketWrapper
 from typing import Callable, NamedTuple
 from collections import namedtuple
 
+
+def toNamedTuple(content: dict, name: str = "namedtuple") -> NamedTuple:
+    """ Recursively converts a `dictionary` to a `namedtuple`. """
+
+    T = namedtuple(name, content.keys())
+    values = []
+    for k, v in content.items():
+        if isinstance(v, dict):
+            values.append(toNamedTuple(v, k))
+        else:
+            values.append(v)
+
+    return T(*values)
+
+
 class Api:
     """ Construct an instance of the OpenSpace API. \n
     :param socket - An instance of SocketWrapper.
@@ -356,20 +371,7 @@ class Api:
 
                 subPyLibrary[func['name']] = generateAsyncSingleRetFunction(fullFunctionName)
 
-        return self.toNamedTuple(pyLibrary, libraryName)
-
-    def toNamedTuple(self, content: dict, name: str = "namedtuple") -> NamedTuple:
-        """ Recursively converts a `dictionary` to a `namedtuple`. """
-
-        T = namedtuple(name, content.keys())
-        values = []
-        for k, v in content.items():
-            if isinstance(v, dict):
-                values.append(self.toNamedTuple(v, k))
-            else:
-                values.append(v)
-
-        return T(*values)
+        return toNamedTuple(pyLibrary, libraryName)
 
     async def singleReturnLibrary(self):
         """ Get an object representing the OpenSpace lua library. \n

--- a/src/openspace/src/socketwrapper.py
+++ b/src/openspace/src/socketwrapper.py
@@ -56,7 +56,7 @@ class SocketWrapper:
     async def connect(self):
         self._client = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
         self._client.setblocking(False)
-        self._loop = asyncio.get_event_loop()
+        self._loop = asyncio.get_running_loop()
         try:
             await self._loop.sock_connect(self._client, (self._address, self._port))
             self._disconnecting = False


### PR DESCRIPTION
This MR does some cleanup and provides a way for the user to wrap API calls, for instance to make them synchronous.

I took the liberty to remove `multiReturnLibrary`, which didn't seem used, and, as a consequence, to deprecate `singleReturnLibrary` in favor of `library`.

cc @engbergandreas @alexanderbock 